### PR TITLE
Fix DemoLand book URL

### DIFF
--- a/web/src/lib/leftSidebar/Welcome.svelte
+++ b/web/src/lib/leftSidebar/Welcome.svelte
@@ -9,7 +9,7 @@
     let doNotShowOnPageLoad: boolean =
         localStorage.getItem("doNotShowWelcome") === "true";
 
-    const bookUrl: string = "https://ciupava.github.io/LandUseDemonstrator";
+    const bookUrl: string = "https://urban-analytics-technology-platform.github.io/demoland-project";
 
     // Whether the welcome screen is visible (initialised based on page load
     // setting, but can be toggled if the user wants to re-display it)


### PR DESCRIPTION
The original URL does not exist anymore, hopefully I got the new URL right.